### PR TITLE
日历加入深渊讨伐战

### DIFF
--- a/base.py
+++ b/base.py
@@ -768,7 +768,8 @@ class CalendarEventType(Enum):
     SHRINE = 37
     TEMPLE = 38
     DUNGEON = 45
-
+    ABYSS = -4
+    
     @classmethod
     def get_by_value(cls, value: int) -> "CalendarEventType":
         return next((item for item in cls if item.value == value), cls.UNKNOWN)

--- a/database.py
+++ b/database.py
@@ -16,6 +16,7 @@ from sqlalchemy.future import select
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 from .base import FilePath
 from .table import (
+    AbyssScheduleData,
     AilmentData,
     CampaignFreegacha,
     CampaignSchedule,
@@ -1249,7 +1250,30 @@ class PCRDatabase:
             ]
         else:
             return []
+        
+    @session
+    async def get_abyss_schedule(self, session: AsyncSession, limit: int = 1):
 
+        query = (
+            select(
+                literal(-4).label("type"),
+                AbyssScheduleData.talent_id.label("value"),
+                AbyssScheduleData.start_time,
+                AbyssScheduleData.end_time,
+            )
+            .order_by(AbyssScheduleData.abyss_id.desc())
+            .limit(limit)
+        )
+
+        result = await session.execute(query)
+        if result := result.fetchall():
+            return [
+                CalendarEvent(**dict(zip(CalendarEvent.__annotations__.keys(), item)))
+                for item in result
+            ]
+        else:
+            return []
+        
     @session
     async def get_birthday_list(
         self,

--- a/handle.py
+++ b/handle.py
@@ -570,6 +570,10 @@ async def get_schedule(type_: str = None, data: PCRDatabase = None):
         calendar_event_list += await data.get_colosseum_event()
     except Exception as e:
         logger.warning(f"获取斗技场事件失败: {e}")
+    try:
+        calendar_event_list += await data.get_abyss_schedule(limit=2)
+    except Exception as e:
+        logger.warning(f"获取深渊讨伐战事件失败: {e}")
 
     is_fix_jp = type_ == "jp"
     in_progress_list, coming_soon_list = fliter_event_list(

--- a/model.py
+++ b/model.py
@@ -230,6 +230,16 @@ class CalendarEvent:
             events.append(CalendarEventData("次元断层", "", ""))
         elif event_type == CalendarEventType.COLOSSEUM:
             events.append(CalendarEventData("斗技场", "", ""))
+        elif event_type == CalendarEventType.ABYSS:
+            abyss_map = {
+                1: ("-火", Color.red.value),
+                2: ("-水", Color.blue.value),
+                3: ("-风", Color.green.value),
+                4: ("-光", Color.gold.value),
+                5: ("-暗", Color.purple.value)
+            }
+            talent_text, front_color = abyss_map.get(self.value, "")     
+            events.append(CalendarEventData("深渊讨伐战", talent_text, "", front_color))
         else:
             try:
                 list_of_types = list(map(int, self.type.split("-")))

--- a/table.py
+++ b/table.py
@@ -1142,3 +1142,12 @@ class UnitTalent(PCRModel, table=True):
     unit_id: int
     talent_id: int
 
+class AbyssScheduleData(PCRModel, table=True):
+    __tablename__ = "abyss_schedule"
+
+    abyss_id: int = Field(primary_key=True)
+    start_time: str
+    end_time: str
+    talent_id: int
+    boss_ticket_id: int
+    title: str


### PR DESCRIPTION
日历加入深渊讨伐战,等pcr-tool数据更新后应该能直接用吧（大概）

## Summary by Sourcery

Add Abyss raid events to the calendar system and integrate them into the schedule retrieval flow.

New Features:
- Support representing Abyss raid events as a new calendar event type with associated elemental variants.
- Expose Abyss raid schedule data from the database for inclusion in aggregated calendar events.

Enhancements:
- Extend the schedule handler to include upcoming Abyss raid events when building the calendar response.